### PR TITLE
Update response_handler.js

### DIFF
--- a/lib/kickbox/http_client/response_handler.js
+++ b/lib/kickbox/http_client/response_handler.js
@@ -7,12 +7,16 @@ response.getBody = function(res, body, callback) {
   var type = res.headers['content-type'], error = null;
 
   // Response body is in JSON
-  if (type.indexOf('json') != -1 && typeof(body) != 'object') {
-    try {
-      body = JSON.parse(body || '{}');
-    } catch (err) {
-      error = err;
+  try{
+    if (type.indexOf('json') != -1 && typeof(body) != 'object') {
+      try {
+        body = JSON.parse(body || '{}');
+      } catch (err) {
+        error = err;
+      }
     }
+  } catch(err) {
+    error = err;
   }
 
   return callback(error, res, body);


### PR DESCRIPTION
Catch error to prevent app from crashing when type is not a `String`
