### PR TITLE
Update response_handler.js

### DIFF
--- a/lib/kickbox/http_client/response_handler.js
+++ b/lib/kickbox/http_client/response_handler.js
@@ -7,12 +7,16 @@ response.getBody = function(res, body, callback) {
   var type = res.headers['content-type'], error = null;
 
   // Response body is in JSON
-  if (type.indexOf('json') != -1 && typeof(body) != 'object') {
-    try {
-      body = JSON.parse(body || '{}');
-    } catch (err) {
-      error = err;
+  try{
+    if (type.indexOf('json') != -1 && typeof(body) != 'object') {
+      try {
+        body = JSON.parse(body || '{}');
+      } catch (err) {
+        error = err;
+      }
     }
+  } catch(err) {
+    error = err;
   }
 
   return callback(error, res, body);


### PR DESCRIPTION
Prevent getting `TypeError: Cannot read property 'indexOf' of undefined` on line 10 (now line 11) when `type` is undefined.
