### PR TITLE
switches tld from .io to .com

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Kickbox determines if an email address is not only valid, but associated with a 
 
 ## Getting Started
 
-To begin, hop over to [kickbox.io](http://kickbox.io) and create a free account. Once you've signed up and logged in, click on **API Settings** and then click **Add API Key**. Take note of the generated API Key - you'll need it to setup the client as explained below.
+To begin, hop over to [kickbox.com](http://kickbox.com) and create a free account. Once you've signed up and logged in, click on **API Settings** and then click **Add API Key**. Take note of the generated API Key - you'll need it to setup the client as explained below.
 
 ## Installation
 
@@ -69,7 +69,7 @@ A successful API call responds with the following values:
 * **disposable** `true | false` - *true* if the email address uses a *disposable* domain like trashmail.com or mailinator.com.
 * **accept_all** `true | false` - *true* if the email was accepted, but the domain appears to accept all emails addressed to that domain.
 * **did_you_mean** `null | string` - Returns a suggested email if a possible spelling error was detected. (`bill.lumbergh@gamil.com` -> `bill.lumbergh@gmail.com`)
-* **sendex** `float` - A quality score of the provided email address ranging between 0 (no quality) and 1 (perfect quality). More information on the Sendex Score can be found [here](http://docs.kickbox.io/v2.0/docs/the-sendex).
+* **sendex** `float` - A quality score of the provided email address ranging between 0 (no quality) and 1 (perfect quality). More information on the Sendex Score can be found [here](http://docs.kickbox.com/v2.0/docs/the-sendex).
 * **email** `string` - Returns a normalized version of the provided email address. (`BoB@example.com` -> `bob@example.com`)
 * **user** `string` - The user (a.k.a local part) of the provided email address. (`bob@example.com` -> `bob`)
 * **domain** `string` - The domain of the provided email address. (`bob@example.com` -> `example.com`)
@@ -89,4 +89,4 @@ MIT
 Report [here](https://github.com/kickboxio/kickbox-node/issues).
 
 ## Need Help?
-help@kickbox.io
+help@kickbox.com

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Kickbox determines if an email address is not only valid, but associated with a 
 
 ## Getting Started
 
-To begin, hop over to [kickbox.com](http://kickbox.com) and create a free account. Once you've signed up and logged in, click on **API Settings** and then click **Add API Key**. Take note of the generated API Key - you'll need it to setup the client as explained below.
+To begin, hop over to [kickbox.com](https://kickbox.com) and create a free account. Once you've signed up and logged in, click on **API Settings** and then click **Add API Key**. Take note of the generated API Key - you'll need it to setup the client as explained below.
 
 ## Installation
 
@@ -69,7 +69,7 @@ A successful API call responds with the following values:
 * **disposable** `true | false` - *true* if the email address uses a *disposable* domain like trashmail.com or mailinator.com.
 * **accept_all** `true | false` - *true* if the email was accepted, but the domain appears to accept all emails addressed to that domain.
 * **did_you_mean** `null | string` - Returns a suggested email if a possible spelling error was detected. (`bill.lumbergh@gamil.com` -> `bill.lumbergh@gmail.com`)
-* **sendex** `float` - A quality score of the provided email address ranging between 0 (no quality) and 1 (perfect quality). More information on the Sendex Score can be found [here](http://docs.kickbox.com/v2.0/docs/the-sendex).
+* **sendex** `float` - A quality score of the provided email address ranging between 0 (no quality) and 1 (perfect quality). More information on the Sendex Score can be found [here](https://docs.kickbox.com/v2.0/docs/the-sendex).
 * **email** `string` - Returns a normalized version of the provided email address. (`BoB@example.com` -> `bob@example.com`)
 * **user** `string` - The user (a.k.a local part) of the provided email address. (`bob@example.com` -> `bob`)
 * **domain** `string` - The domain of the provided email address. (`bob@example.com` -> `example.com`)

--- a/lib/kickbox/http_client/index.js
+++ b/lib/kickbox/http_client/index.js
@@ -29,7 +29,7 @@ client.HttpClient = function (auth, options) {
   }
 
   this.options = {
-    'base': 'https://api.kickbox.io',
+    'base': 'https://api.kickbox.com',
     'api_version': 'v2',
     'user_agent': 'kickbox-node/2.0.0 (https://github.com/kickboxio/kickbox-node)'
   };

--- a/lib/kickbox/http_client/index.js
+++ b/lib/kickbox/http_client/index.js
@@ -1,7 +1,7 @@
 var url = require('url')
-  , request = require('request');
-
-var client = module.exports;
+  , request = require('request')
+  , packageJson = require('../../../package.json') // package is a reserve word
+  , client = module.exports;
 
 client.AuthHandler = require('./auth_handler');
 client.ErrorHandler = require('./error_handler');
@@ -15,6 +15,8 @@ client.Response = require('./response.js');
  * Main HttpClient which is used by Api classes
  */
 client.HttpClient = function (auth, options) {
+  var userAgent = 'kickbox-node/' + packageJson.version + ' (https://github.com/kickboxio/kickbox-node)';
+
   if (!options) {
     options = {};
   }
@@ -23,7 +25,6 @@ client.HttpClient = function (auth, options) {
     auth = {};
   }
 
-
   if (typeof auth == 'string') {
     auth = { 'http_header': auth };
   }
@@ -31,7 +32,7 @@ client.HttpClient = function (auth, options) {
   this.options = {
     'base': 'https://api.kickbox.com',
     'api_version': 'v2',
-    'user_agent': 'kickbox-node/2.0.0 (https://github.com/kickboxio/kickbox-node)'
+    'user_agent': userAgent
   };
 
   for (var key in options) {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "kickbox",
   "version": "2.0.1",
   "description": "Official kickbox API library client for node.js",
-  "author": "Chaitanya Surapaneni <chaitanya.surapaneni@kickbox.io> (https://github.com/kickboxio)",
-  "homepage": "http://kickbox.io",
+  "author": "Chaitanya Surapaneni <chaitanya.surapaneni@kickbox.com> (https://github.com/kickboxio)",
+  "homepage": "http://kickbox.com",
   "keywords": ["free", "email", "validation", "kickbox", "service", "verification", "sendex"],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Given the switch from .io to .com, I updated all links, including email addresses, to use the new kickbox.com domain.